### PR TITLE
FIX: Got rid of liquid warnings

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
 email: info@bela.io
 # TO TEST YOUR BUILD, uncomment this line:
-# baseurl: ""
+baseurl: ""
 # ... and comment out this line:
-baseurl: "https://blog.bela.io"
+# baseurl: "https://blog.bela.io"
 # IMPORTANT! Before deploying, make sure you change them back so the github url is active. 
 future: false
 imageurl: "/assets/images/"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,9 +1,9 @@
 # Site settings
 email: info@bela.io
 # TO TEST YOUR BUILD, uncomment this line:
-baseurl: ""
+# baseurl: ""
 # ... and comment out this line:
-# baseurl: "https://blog.bela.io"
+baseurl: "https://blog.bela.io"
 # IMPORTANT! Before deploying, make sure you change them back so the github url is active. 
 future: false
 imageurl: "/assets/images/"

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -31,18 +31,16 @@ layout: default
   <section class="profile">
     <div class="profile__card">
       <div class="profile__img">
-        <figure class="absolute-bg" style="background-image: url('../../../../assets/images/{{ site.data.authors.[page.author].author-image }}');"></figure>
+        <figure class="absolute-bg" style="background-image: url('../../../../assets/images/{{ site.data.authors[page.author].author-image }}');"></figure>
       </div>
       <div class="profile__container">
-        <h3>{{ site.data.authors.[page.author].name }}</h3>
-        <p>{{ site.data.authors.[page.author].profile }}</p>
-        {% if site.data.authors.[page.author].email or site.data.authors.[page.author].social %}
+        <h3>{{ site.data.authors[page.author].name }}</h3>
+        <p>{{ site.data.authors[page.author].profile }}</p>
+        {% if site.data.authors[page.author].email or site.data.authors[page.author].social %}
           <ul class="profile__social">
-              <li><a class="fa fa-lg fa-envelope" href="mailto:{{ site.data.authors.[page.author].email }}"></a></li>
-              <li><a class="fa fa-lg fa-github" href="http://www.github.com/{{ site.data.authors.[page.author].github }}" target="_blank"></a></li>
-              <li><a class="fa fa-lg fa-twitter" href="http://www.twitter.com/{{ site.data.authors.[page.author].twitter }}" target="_blank"></a></li>
-              <!-- <li><a class="fa fa-lg fa-link" href="{{ site.data.authors.[page.author].link }}" target="_blank"></a></li> -->
-            
+              <li><a class="fa fa-lg fa-envelope" href="mailto:{{ site.data.authors[page.author].email }}"></a></li>
+              <li><a class="fa fa-lg fa-github" href="http://www.github.com/{{ site.data.authors[page.author].github }}" target="_blank"></a></li>
+              <li><a class="fa fa-lg fa-twitter" href="http://www.twitter.com/{{ site.data.authors[page.author].twitter }}" target="_blank"></a></li>
           </ul>
         {% endif %}
       </div>

--- a/docs/_sass/_helpers.scss
+++ b/docs/_sass/_helpers.scss
@@ -24,3 +24,21 @@
 .bg-white {
   background-color: $color-white;
 }
+
+/** 
+ * Front page layout helpers
+ */
+
+.prev-left {
+
+  >img {
+    width: 95%;
+    height: auto;
+  }
+  margin-bottom: 1em;
+}
+
+.prev-right {
+}
+
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,10 +26,15 @@ layout: default
         {% for post in paginator.posts %}
           <li class="preview" itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting">
             <a class="preview__link" href="{{ post.url | prepend: site.baseurl }}" itemprop="url">
-              <span class="preview__date" itemprop="datePublished" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</span>
-              <h2 class="preview__header" itemprop="name">{{ post.title }}</h2>
-              <p class="preview__excerpt" itemprop="description">{{ post.content | strip_html | replace_regex: '#.*', '' | truncatewords: 30 }}</p>
-              <span class="preview__more">Read More</span>
+              <div class="prev-left">
+                <img src="{{ site.baseurl}}/assets/images/{{ post.image }}" />
+              </div>
+              <div class="prev-right">
+                <span class="preview__date" itemprop="datePublished" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%b %-d, %Y" }}</span>
+                <h2 class="preview__header" itemprop="name">{{ post.title }}</h2>
+                <p class="preview__excerpt" itemprop="description">{{ post.content | strip_html | replace_regex: '#.*', '' | truncatewords: 30 }}</p>
+                <span class="preview__more">Read More</span>
+              </div>
             </a>
           </li>
         {% endfor %}


### PR DESCRIPTION
There was a small syntax error that was causing those really weird and very verbose command line warnings when the site was built. Resolved. Hooray.